### PR TITLE
Allow case sensitive commands

### DIFF
--- a/ssh-restrict
+++ b/ssh-restrict
@@ -56,6 +56,8 @@ except KeyError:
     sys.exit(RETURN_CODE_WRONG_USAGE)
 
 config = ConfigParser.RawConfigParser()
+# Override `optionxform` to bypass conversion of keys to lowercase
+config.optionxform = lambda option: option
 config.readfp(open(sys.argv[1]))
 
 for config_pattern, config_command in config.items(CONFIG_SECTION_NAME_COMMANDS):

--- a/test/config
+++ b/test/config
@@ -8,3 +8,4 @@ bad_escape (\w\=+) = echo {0}
 bad_regex (\w=+) = echo {0}
 bad_formatting (\d+) = echo {1}
 not_found = not_found
+UpperLower = echo UpperLower

--- a/test/test.py
+++ b/test/test.py
@@ -46,3 +46,7 @@ def test_escape_exception():
 def test_command_formatting():
     os.environ["SSH_ORIGINAL_COMMAND"] = "bad_formatting 123"
     assert call(["./ssh-restrict", "./test/config"]) == EXPECTED_RETURN_CODE_INTERNAL_ERROR
+
+def test_upper_lower():
+    os.environ["SSH_ORIGINAL_COMMAND"] = "UpperLower"
+    assert b"UpperLower\n" == check_output(["./ssh-restrict", "./test/config"])


### PR DESCRIPTION
In reference to issue #3 from @vinzent

Summary:
  * Override optionxform function to prevent
    case conversion
  * Add additional new test to confirm
    case sensitive command are passing.