### PR TITLE
Port to python3 with backward compatibility

### DIFF
--- a/.github/workflows/pytest_ssh-restrict.yml
+++ b/.github/workflows/pytest_ssh-restrict.yml
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------------------------
+# Run test 
+# Author: Urs Roesch https://github.com/uroesch
+# Version: 0.1.0
+# -----------------------------------------------------------------------------
+name: pytest_ssh-restrict
+
+on:
+  push:
+    branches:
+    - workflow/*
+  pull_request:
+    branches:
+    - master
+    - main 
+
+jobs:
+  pytest_ssh-restrict:
+    timeout-minutes: 15
+    #runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: python:${{ matrix.python }}
+    strategy:
+      matrix:
+        python:
+          - '2.7'
+          - '3.3'
+          - '3.4'
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install pytest
+      shell: bash
+      run: pip install pytest
+
+    - name: Test ssh-restrict
+      shell: bash
+      run: pytest test/test.py

--- a/ssh-restrict
+++ b/ssh-restrict
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
-import ConfigParser
+
 import shlex
 import sys
 
 import os
 import re
 
+# import for python 2 and python 3
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
 
 RETURN_CODE_WRONG_USAGE = 3
 RETURN_CODE_COMMAND_NOT_FOUND = 3
@@ -15,6 +20,8 @@ CONFIG_SECTION_NAME_COMMANDS = "commands"
 
 buffer_exception_uncritical = []
 
+def alert(message):
+    sys.stderr.write(message + "\n")
 
 def match_command(pattern, command):
     # noinspection PyBroadException
@@ -24,9 +31,10 @@ def match_command(pattern, command):
         # noinspection PyBroadException
         try:
             if shlex.split(command)[0] == shlex.split(pattern)[0]:
-                print >> sys.stderr, \
+                alert( \
                     "ssh-restrict: failed to evaluate regex '%s' for command '%s': %s" % \
-                    (pattern, command, sys.exc_info()[1])
+                    (pattern, command, sys.exc_info()[1]) \
+                )
                 sys.exit(RETURN_CODE_INTERNAL_ERROR)
         except:
             buffer_exception_uncritical.append(
@@ -40,22 +48,23 @@ def get_formatted_command_parts(command_template, command_match):
     try:
         return shlex.split(command_template.format(*command_match.groups()))
     except:
-        print >> sys.stderr, "ssh-restrict: formatting command '%s' failed: %s" % \
-                             (command_template, sys.exc_info()[1])
+        alert("ssh-restrict: formatting command '%s' failed: %s" % \
+            (command_template, sys.exc_info()[1])
+        )
         sys.exit(RETURN_CODE_INTERNAL_ERROR)
 
 
 if len(sys.argv) != 2:
-    print >> sys.stderr, "Usage: ssh-restrict CONFIG"
+    alert("Usage: ssh-restrict CONFIG")
     sys.exit(RETURN_CODE_WRONG_USAGE)
 
 try:
     original_command = os.environ["SSH_ORIGINAL_COMMAND"]
 except KeyError:
-    print >> sys.stderr, "ssh-restrict: $SSH_ORIGINAL_COMMAND is not set"
+    alert("ssh-restrict: $SSH_ORIGINAL_COMMAND is not set")
     sys.exit(RETURN_CODE_WRONG_USAGE)
 
-config = ConfigParser.RawConfigParser()
+config = configparser.RawConfigParser()
 # Override `optionxform` to bypass conversion of keys to lowercase
 config.optionxform = lambda option: option
 config.readfp(open(sys.argv[1]))
@@ -67,12 +76,11 @@ for config_pattern, config_command in config.items(CONFIG_SECTION_NAME_COMMANDS)
         try:
             os.execvp(command_parts[0], command_parts)
         except OSError:
-            print >> sys.stderr, "ssh-restrict: command not found: %s" % \
-                                 command_parts[0]
+            alert("ssh-restrict: command not found: %s" % command_parts[0])
             sys.exit(RETURN_CODE_COMMAND_NOT_FOUND)
 else:
-    print >> sys.stderr, "ssh-restrict: command not defined: %s" % original_command
+    alert("ssh-restrict: command not defined: %s" % original_command)
     if len(buffer_exception_uncritical) > 0:
-        print >> sys.stderr, "\n".join(buffer_exception_uncritical)
+        alert("\n".join(buffer_exception_uncritical))
         sys.exit(RETURN_CODE_INTERNAL_ERROR)
     sys.exit(RETURN_CODE_WRONG_USAGE)


### PR DESCRIPTION
Hi Max

It's me once more with a PR. One of my clients is still using ssh-restrict. As there are still some legacy hosts I remodeled the script a bit and added a github actions to ensure all the common versions of python are working and backward compatibility is given.

Here a short list of the most important changes:  

- Refactoring code to run both on python3 and python2.
  - Adding an alert function to replace print.
  - Import ConfigParser as configparser for python2.
  - Only use 'configparser' all lowercase.
- Adding github action tests to ensure compatibility is tested.

Closes #6